### PR TITLE
fixes input/results container width

### DIFF
--- a/components/Form.tsx
+++ b/components/Form.tsx
@@ -48,7 +48,7 @@ export default function Form() {
       { result
         ?
         <div>
-          <div>
+          <div className={styles.textAreaContainer}>
             <div className={styles.result}>{result}</div>
           </div>
 
@@ -66,7 +66,7 @@ export default function Form() {
           </button>
         </div>
         :
-        <div>
+        <div className={styles.textAreaContainer}>
           <textarea
             className={styles.textArea}
             onChange={e => setContent(e.target.value)}

--- a/components/form.module.css
+++ b/components/form.module.css
@@ -2,6 +2,10 @@
   text-align: center;
 }
 
+.textAreaContainer {
+  width: 300px;
+}
+
 .textArea {
   width: 100%;
   border-radius: 6px;


### PR DESCRIPTION
After:
![tl;dr papers 2021-06-13 22-35-59](https://user-images.githubusercontent.com/1177031/121863649-c7413700-cc97-11eb-92b7-e300218d612b.png)
 
![tl;dr papers 2021-06-13 22-35-23](https://user-images.githubusercontent.com/1177031/121863666-cb6d5480-cc97-11eb-9239-31b78b4f0679.png)

Before:
![tl;dr papers 2021-06-13 22-35-45](https://user-images.githubusercontent.com/1177031/121863693-d32cf900-cc97-11eb-9056-9577ac0f3b2b.png)
![tl;dr papers 2021-06-13 22-35-38](https://user-images.githubusercontent.com/1177031/121863708-d7591680-cc97-11eb-8f3d-09fd8bb61780.png)
